### PR TITLE
feat(carrier-with-rates) Add samples for validate shipment method

### DIFF
--- a/carrier-with-rates/src/index.ts
+++ b/carrier-with-rates/src/index.ts
@@ -8,6 +8,7 @@ import {
   SchedulePickup,
   CancelPickup,
   Track,
+  ValidateShipment,
 } from './methods';
 import { Metadata } from './definitions';
 
@@ -24,4 +25,5 @@ export default {
   SchedulePickup,
   CancelPickup,
   Track,
+  ValidateShipment,
 } satisfies CarrierAppDefinition;

--- a/carrier-with-rates/src/methods/index.ts
+++ b/carrier-with-rates/src/methods/index.ts
@@ -6,3 +6,4 @@ export * from './create-manifest';
 export * from './schedule-pickup';
 export * from './cancel-pickup';
 export * from './track';
+export * from './validate-shipment';

--- a/carrier-with-rates/src/methods/validate-shipment.ts
+++ b/carrier-with-rates/src/methods/validate-shipment.ts
@@ -1,0 +1,8 @@
+import { ValidateShipmentRequest, ValidateShipmentResponse } from "@shipengine/connect-carrier-api";
+import { logger, NotImplementedError } from "@shipengine/connect-runtime";
+
+export const ValidateShipment = async (request: ValidateShipmentRequest): Promise<ValidateShipmentResponse> => {
+    logger.info('This is a log that I can find using the `connect logs` command after publishing.')
+
+    throw new NotImplementedError(); 
+}


### PR DESCRIPTION
Main purpose of this change is to add possibility to validate by carrier app shipment's prototype during created/update order.
Assumption:

validation can be optionally force during create/update shipment method (depend on request property ValidateShipmentMode: NoValidation, ValidateOnly, ValidateAndFail)
validate shipment method use model similar to create label request so connectApp should implement carrier required validation only once
ShipEngine calls gateway directly, SPS is omitted
for future use (dedicated ShipEngine ValidateShipment method) request/response models are extended to service collection
Service is identified by service code and correlation id
response error contains message, field name, field value and carrier error code
ShipEngine validation return success ("has_errors": false) when carrier app does not implement validation method
Changes related to adding new method ValidateShipment at connectApp.
Adjust models for new method.
Add template for generating it during connect init.

Related PR's:
Connect: https://github.com/shipstation/ipaas-connect/pull/828
Carrier-api-common https://github.com/shipstation/integrations-shipping/pull/2523
Example of usage in Dummy-module: https://github.com/shipstation/integrations-shipping/pull/2685
ShipEngine: https://github.com/shipstation/shipstation/pull/17118